### PR TITLE
Add autoClose flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ class App extends React.Component<any, State> {
                 window: false,
               })
             }
+            autoClose
           >
             <MyDiv>Look, it&apos;s blue! There are no borders either.</MyDiv>
           </StyledWindowPortal>
@@ -71,6 +72,7 @@ The styled window component can take the following props
 | Prop Name   | Type     | Default Value | Description                                 |
 | ----------- | -------- | ------------- | ------------------------------------------- |
 | onClose     | function | N/A           | A function called when the window is closed |
+| autoClose   | boolean  | false         | Close child window when parent is closed    |
 | title       | string   | New Window    | The title of the window                     |
 | windowProps | object   |               | See below                                   |
 

--- a/example/src/index.tsx
+++ b/example/src/index.tsx
@@ -15,6 +15,7 @@ const GlobalStyle = createGlobalStyle`
 
 interface State {
   window: boolean;
+  autoClose: boolean;
 }
 
 class App extends React.Component<any, State> {
@@ -23,6 +24,7 @@ class App extends React.Component<any, State> {
 
     this.state = {
       window: false,
+      autoClose: false,
     };
   }
 
@@ -39,6 +41,22 @@ class App extends React.Component<any, State> {
         >
           Click me to {this.state.window ? 'close' : 'open'} the window
         </button>
+
+        <p>
+          <label>
+            <input
+              type="checkbox"
+              checked={this.state.autoClose}
+              onChange={() =>
+                this.setState({
+                  autoClose: !this.state.autoClose,
+                })
+              }
+            />
+            Auto close child window when parent is closed
+          </label>
+        </p>
+
         {this.state.window && (
           <StyledWindowPortal
             onClose={() =>
@@ -46,7 +64,7 @@ class App extends React.Component<any, State> {
                 window: false,
               })
             }
-            autoClose
+            autoClose={this.state.autoClose}
           >
             <MyDiv>Look, it&apos;s blue! There are no borders either.</MyDiv>
           </StyledWindowPortal>

--- a/example/src/index.tsx
+++ b/example/src/index.tsx
@@ -46,6 +46,7 @@ class App extends React.Component<any, State> {
                 window: false,
               })
             }
+            autoClose
           >
             <MyDiv>Look, it&apos;s blue! There are no borders either.</MyDiv>
           </StyledWindowPortal>

--- a/src/StyledWindowPortal.tsx
+++ b/src/StyledWindowPortal.tsx
@@ -100,6 +100,18 @@ class StyledWindowPortal extends React.PureComponent<Props, State> {
     }
   }
 
+  componentDidUpdate(prevProps: Props) {
+    if (!prevProps.autoClose && this.props.autoClose) {
+      // autoClose became enabled
+      window.addEventListener("unload", this.closeExternalWindow);
+    }
+
+    if (prevProps.autoClose && !this.props.autoClose) {
+      // autoClose became disabled
+      window.removeEventListener("unload", this.closeExternalWindow);
+    }
+  }
+
   componentWillUnmount() {
     if (this.props.autoClose) {
       window.removeEventListener("unload", this.closeExternalWindow);

--- a/src/StyledWindowPortal.tsx
+++ b/src/StyledWindowPortal.tsx
@@ -18,6 +18,7 @@ type WindowProps = {
 
 type Props = {
   onClose: ((this: WindowEventHandlers, ev: Event) => any) | null;
+  autoClose: boolean;
   title?: string;
   windowProps?: WindowProps;
   children: ReactNode;
@@ -93,11 +94,25 @@ class StyledWindowPortal extends React.PureComponent<Props, State> {
         }
       }
     );
+
+    if (this.props.autoClose) {
+      window.addEventListener("unload", this.closeExternalWindow);
+    }
   }
 
   componentWillUnmount() {
-    if (!!this.state.externalWindow) this.state.externalWindow.close();
+    if (this.props.autoClose) {
+      window.removeEventListener("unload", this.closeExternalWindow);
+    }
+
+    this.closeExternalWindow();
   }
+
+  closeExternalWindow = () => {
+    if (this.state.externalWindow && !this.state.externalWindow.closed) {
+        this.state.externalWindow.close();
+    }
+  };
 
   windowPropsToString() {
     const mergedProps: { [key: string]: any } = {


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/506532/60768202-f07be480-a0ca-11e9-90ca-2d413f83c7de.png">

Add the `autoClose` prop to `<StyledWindowPortal />` component to close child window automatically when parent is closed (via window close, tab close, or refresh).
